### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/run-chat-eval-pf-pipeline.yml
+++ b/.github/workflows/run-chat-eval-pf-pipeline.yml
@@ -68,10 +68,10 @@ jobs:
             # assert.py will return True or False, but bash expects lowercase.
             if ${ASSERT,,} ; then
               echo "::debug::Prompt flow run met the quality bar and can be deployed."
-              echo "::set-output name=result::true"
+              echo "result=true" >> "$GITHUB_OUTPUT"
             else
               echo "::warning::Prompt flow run didn't meet quality bar."
-              echo "::set-output name=result::false"
+              echo "result=false" >> "$GITHUB_OUTPUT"
             fi
     - name: Show the assert result
       run: echo "Assert result is:" ${{ steps.jobMetricAssert.outputs.result }}

--- a/.github/workflows/run-intent-eval-pf-pipeline copy.yml
+++ b/.github/workflows/run-intent-eval-pf-pipeline copy.yml
@@ -68,10 +68,10 @@ jobs:
             # assert.py will return True or False, but bash expects lowercase.
             if ${ASSERT,,} ; then
               echo "::debug::Prompt flow run met the quality bar and can be deployed."
-              echo "::set-output name=result::true"
+              echo "result=true" >> "$GITHUB_OUTPUT"
             else
               echo "::warning::Prompt flow run didn't meet quality bar."
-              echo "::set-output name=result::false"
+              echo "result=false" >> "$GITHUB_OUTPUT"
             fi
     - name: Show the assert result
       run: echo "Assert result is:" ${{ steps.jobMetricAssert.outputs.result }}

--- a/.github/workflows/run-support-eval-pf-pipeline.yml
+++ b/.github/workflows/run-support-eval-pf-pipeline.yml
@@ -68,10 +68,10 @@ jobs:
             # assert.py will return True or False, but bash expects lowercase.
             if ${ASSERT,,} ; then
               echo "::debug::Prompt flow run met the quality bar and can be deployed."
-              echo "::set-output name=result::true"
+              echo "result=true" >> "$GITHUB_OUTPUT"
             else
               echo "::warning::Prompt flow run didn't meet quality bar."
-              echo "::set-output name=result::false"
+              echo "result=false" >> "$GITHUB_OUTPUT"
             fi
     - name: Show the assert result
       run: echo "Assert result is:" ${{ steps.jobMetricAssert.outputs.result }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter