### PR TITLE
Reading existing config.json file instead of writing it

### DIFF
--- a/deployment/deploy_pf_utils.py
+++ b/deployment/deploy_pf_utils.py
@@ -1,0 +1,37 @@
+# import required libraries
+import os
+from azure.ai.ml import MLClient
+from azure.ai.ml.entities import WorkspaceConnection
+# Import required libraries
+from azure.identity import DefaultAzureCredential, InteractiveBrowserCredential
+
+# Import required libraries
+from azure.identity import DefaultAzureCredential, InteractiveBrowserCredential
+
+def push_pf(flow_path, pf_name_suffix, type):
+
+    try:
+        credential = DefaultAzureCredential()
+        # Check if given credential can get token successfully.
+        credential.get_token("https://management.azure.com/.default")
+    except Exception as ex:
+        # Fall back to InteractiveBrowserCredential in case DefaultAzureCredential not work
+        credential = InteractiveBrowserCredential()
+
+    config_path = "../config.json"
+    from promptflow.azure import PFClient
+    pf_azure_client = PFClient.from_config(credential=credential, path=config_path)
+
+    # Create unique name for pf name with date time
+    import datetime
+    now = datetime.datetime.now()
+    pf_name = "{}-{}".format(pf_name_suffix, now.strftime("%Y-%m-%d-%H-%M-%S"))
+
+    print("Creating prompt flow {} to {} ({})".format(flow_path, pf_name, type))
+
+    # Runtime no longer needed (not in flow schema)
+    flow = pf_azure_client.flows.create_or_update(
+        flow=flow_path,
+        display_name=pf_name,
+        type=type)
+    print("Created prompt flow", pf_name)

--- a/deployment/deployment.sh
+++ b/deployment/deployment.sh
@@ -1,16 +1,22 @@
+#!/bin/bash
+
+set -e
+
 # get config.json
-echo "Writing config.json file for PromptFlow usage..."
-subscriptionId=$(az account show --query id -o tsv)
-resourceGroupName=$(az group show --name $resourceGroupName --query name -o tsv)
-mlProjectName=$(az deployment group show --name contchat --resource-group $resourceGroupName --query properties.outputs.mlproject_name.value -o tsv)
+
+echo "Reading config.json file for PromptFlow usage..."
+subscriptionId=$(cat config.json | jq -r .subscription_id)
+resourceGroupName=$(cat config.json | jq -r .resource_group)
+mlProjectName=$(cat config.json | jq -r .workspace_name)
+
+echo "subscriptionId: ${subscriptionId}"
+echo "resourceGroupName: ${resourceGroupName}"
+echo "mlProjectName: ${mlProjectName}"
 
 # create a random hash for the endpoint name all lowercase letters
 endpointName="contoso-chat-$RANDOM"
 # create a random hash for the deployment name
 deploymentName="contoso-chat-$RANDOM"
-
-echo "{\"subscription_id\": \"$subscriptionId\", \"resource_group\": \"$resourceGroupName\", \"workspace_name\": \"$mlProjectName\"}" > config.json
-$(cat principal.txt) --secret-permissions get list
 
 # register promptflow as model
 echo "Registering PromptFlow as a model in Azure ML..."

--- a/deployment/push_and_deploy_pf.ipynb
+++ b/deployment/push_and_deploy_pf.ipynb
@@ -9,74 +9,154 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# import required libraries\n",
-    "import os\n",
-    "from azure.ai.ml import MLClient\n",
-    "from azure.ai.ml.entities import WorkspaceConnection\n",
-    "# Import required libraries\n",
-    "from azure.identity import DefaultAzureCredential, InteractiveBrowserCredential\n",
-    "\n",
-    "# Import required libraries\n",
-    "from azure.identity import DefaultAzureCredential, InteractiveBrowserCredential\n",
-    "\n",
-    "try:\n",
-    "    credential = DefaultAzureCredential()\n",
-    "    # Check if given credential can get token successfully.\n",
-    "    credential.get_token(\"https://management.azure.com/.default\")\n",
-    "except Exception as ex:\n",
-    "    # Fall back to InteractiveBrowserCredential in case DefaultAzureCredential not work\n",
-    "    credential = InteractiveBrowserCredential()"
+    "from deploy_pf_utils import push_pf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.1 Push contoso-chat"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Found the config file in: ../config.json\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating prompt flow ../contoso-chat/ to contoso-chat-2024-03-05-02-55-22 (chat)\n",
+      "Flow created successfully:\n",
+      "{\n",
+      "    \"name\": \"9ca0bee6-54d8-4181-805f-52ecf2c88841\",\n",
+      "    \"type\": \"chat\",\n",
+      "    \"path\": \"Users/cedricvidal/promptflow/contoso-chat-03-05-2024-02-55-22/flow.dag.yaml\",\n",
+      "    \"code\": \"azureml://locations/swedencentral/workspaces/e1957cba-343f-41f0-afcf-a3a5381717ab/flows/9ca0bee6-54d8-4181-805f-52ecf2c88841\",\n",
+      "    \"display_name\": \"contoso-chat-2024-03-05-02-55-22\",\n",
+      "    \"owner\": {\n",
+      "        \"user_object_id\": \"0942ebd5-1ebf-4c2c-b94c-a4b753a9114e\",\n",
+      "        \"user_tenant_id\": \"72f988bf-86f1-41af-91ab-2d7cd011db47\",\n",
+      "        \"user_name\": \"Cedric Vidal\"\n",
+      "    },\n",
+      "    \"is_archived\": false,\n",
+      "    \"created_date\": \"2024-03-05 02:55:34.841769+00:00\",\n",
+      "    \"flow_portal_url\": \"https://ai.azure.com/projectflows/9ca0bee6-54d8-4181-805f-52ecf2c88841/e1957cba-343f-41f0-afcf-a3a5381717ab/details/Flow?wsid=/subscriptions/7b6a2141-95cf-4729-aa87-872160b87c03/resourcegroups/contchat-rg/providers/Microsoft.MachineLearningServices/workspaces/contoso-chat-sf-aiproj\"\n",
+      "}\n",
+      "Created prompt flow contoso-chat-2024-03-05-02-55-22\n"
+     ]
+    }
+   ],
    "source": [
-    "config_path = \"../config.json\"\n",
-    "from promptflow.azure import PFClient\n",
-    "pf_azure_client = PFClient.from_config(credential=credential, path=config_path)"
+    "push_pf(flow_path=\"../contoso-chat/\", pf_name_suffix=\"contoso-chat\", type=\"chat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.2 Push contoso-support"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Found the config file in: ../config.json\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flow created successfully:\n",
+      "{\n",
+      "    \"name\": \"d33e56a7-5d0f-4a64-ac7f-e1fe6b16dce3\",\n",
+      "    \"type\": \"chat\",\n",
+      "    \"path\": \"Users/cedricvidal/promptflow/contoso-support-03-05-2024-02-47-55/flow.dag.yaml\",\n",
+      "    \"code\": \"azureml://locations/swedencentral/workspaces/e1957cba-343f-41f0-afcf-a3a5381717ab/flows/d33e56a7-5d0f-4a64-ac7f-e1fe6b16dce3\",\n",
+      "    \"display_name\": \"contoso-support-2024-03-05-02-47-55\",\n",
+      "    \"owner\": {\n",
+      "        \"user_object_id\": \"0942ebd5-1ebf-4c2c-b94c-a4b753a9114e\",\n",
+      "        \"user_tenant_id\": \"72f988bf-86f1-41af-91ab-2d7cd011db47\",\n",
+      "        \"user_name\": \"Cedric Vidal\"\n",
+      "    },\n",
+      "    \"is_archived\": false,\n",
+      "    \"created_date\": \"2024-03-05 02:48:08.945995+00:00\",\n",
+      "    \"flow_portal_url\": \"https://ai.azure.com/projectflows/d33e56a7-5d0f-4a64-ac7f-e1fe6b16dce3/e1957cba-343f-41f0-afcf-a3a5381717ab/details/Flow?wsid=/subscriptions/7b6a2141-95cf-4729-aa87-872160b87c03/resourcegroups/contchat-rg/providers/Microsoft.MachineLearningServices/workspaces/contoso-chat-sf-aiproj\"\n",
+      "}\n",
+      "Creating prompt flow <promptflow.azure._entities._flow.Flow object at 0x7f105f290390>\n"
+     ]
+    }
+   ],
    "source": [
-    "# Create unique name for pf name with date time\n",
-    "import datetime\n",
-    "now = datetime.datetime.now()\n",
-    "pf_name = \"contoso-chat-{}\".format(now.strftime(\"%Y-%m-%d-%H-%M-%S\"))\n"
+    "push_pf(flow_path=\"../contoso-support/\", pf_name_suffix=\"contoso-support\", type=\"chat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.3 Push contoso-intent"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Found the config file in: ../config.json\n",
+      "[2024-03-05 02:49:46,915][promptflow][WARNING] - Schema validation warnings: [id: Unknown field., name: Unknown field.]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flow created successfully:\n",
+      "{\n",
+      "    \"name\": \"26b8b26b-fa4c-4244-96b1-6723a3e11322\",\n",
+      "    \"type\": \"chat\",\n",
+      "    \"path\": \"Users/cedricvidal/promptflow/contoso-intent-03-05-2024-02-49-46/flow.dag.yaml\",\n",
+      "    \"code\": \"azureml://locations/swedencentral/workspaces/e1957cba-343f-41f0-afcf-a3a5381717ab/flows/26b8b26b-fa4c-4244-96b1-6723a3e11322\",\n",
+      "    \"display_name\": \"contoso-intent-2024-03-05-02-49-46\",\n",
+      "    \"owner\": {\n",
+      "        \"user_object_id\": \"0942ebd5-1ebf-4c2c-b94c-a4b753a9114e\",\n",
+      "        \"user_tenant_id\": \"72f988bf-86f1-41af-91ab-2d7cd011db47\",\n",
+      "        \"user_name\": \"Cedric Vidal\"\n",
+      "    },\n",
+      "    \"is_archived\": false,\n",
+      "    \"created_date\": \"2024-03-05 02:49:56.452073+00:00\",\n",
+      "    \"flow_portal_url\": \"https://ai.azure.com/projectflows/26b8b26b-fa4c-4244-96b1-6723a3e11322/e1957cba-343f-41f0-afcf-a3a5381717ab/details/Flow?wsid=/subscriptions/7b6a2141-95cf-4729-aa87-872160b87c03/resourcegroups/contchat-rg/providers/Microsoft.MachineLearningServices/workspaces/contoso-chat-sf-aiproj\"\n",
+      "}\n",
+      "Creating prompt flow <promptflow.azure._entities._flow.Flow object at 0x7f105a1aaf90>\n"
+     ]
+    }
+   ],
    "source": [
-    "# Runtime no longer needed (not in flow schema)\n",
-    "# load flow\n",
-    "flow = \"../contoso-chat/\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "contoso_chat_flow = pf_azure_client.flows.create_or_update(\n",
-    "    flow=flow,\n",
-    "    display_name=pf_name,\n",
-    "    type=\"chat\")\n",
-    "print(\"Creating prompt flow\", contoso_chat_flow)"
+    "push_pf(flow_path=\"../contoso-intent/\", pf_name_suffix=\"contoso-intent\", type=\"chat\")"
    ]
   },
   {
@@ -103,7 +183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We might want to reverse the logic for getting the sub ID, resource group and ml project name for the following reasons:
- `config.json` is already generated by the `provision.sh` script
- `resourceGroupName` is defined using a non set version of itself, which fails the `az group show` command.

What do you think?
