### PR TITLE
fix cognitive provision error by remove customSubDomainName

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -188,7 +188,6 @@ module openai 'core/ai/cognitiveservices.bicep' = {
     location: location
     tags: tags
     kind: 'AIServices'
-    customSubDomainName: openAiSubdomain
     deployments: [
       {
         name: 'gpt-35-turbo'


### PR DESCRIPTION
fix azd provision error by remove customSubDomainName from module openai 'core/ai/cognitiveservices.bicep' which causing customSubDomainName error when deploy using azd 