### PR TITLE
fix azd cognitive provision error

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -188,7 +188,6 @@ module openai 'core/ai/cognitiveservices.bicep' = {
     location: location
     tags: tags
     kind: 'AIServices'
-    customSubDomainName: openAiSubdomain
     deployments: [
       {
         name: 'gpt-35-turbo'


### PR DESCRIPTION
fix azd provision error by removing customSubDomainName from module openai which causing duplication error which happen during the provision process in azd command