### PR TITLE
Use shuf instead of $RANDOM

### DIFF
--- a/infra/hooks/deployment.sh
+++ b/infra/hooks/deployment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Loading azd .env file from current environment..."
 
@@ -10,9 +10,13 @@ $(azd env get-values)
 EOF
 
 # create a random hash for the endpoint name all lowercase letters
-endpointName="contoso-chat-$RANDOM"
+endpointSuffix=`shuf -i 10000-99999 -n 1`
+endpointName="contoso-chat-$endpointSuffix"
+echo "Using endpoint name: $endpointName"
 # create a random hash for the deployment name
-deploymentName="contoso-chat-$RANDOM"
+deploymentNameSuffix=`shuf -i 10000-99999 -n 1`
+deploymentName="contoso-chat-$deploymentNameSuffix"
+echo "Using deployment name: $deploymentName"
 
 az extension add -n ml -y
 

--- a/infra/hooks/deployment.sh
+++ b/infra/hooks/deployment.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Loading azd .env file from current environment..."
 


### PR DESCRIPTION
$RANDOM is only available in bash. The devcontainer default shell is dash, so the names being generated for the endpoint and deployment had a trailing hyphen which caused deployment to fail ("String does not match expected pattern.").